### PR TITLE
fix unused 

### DIFF
--- a/proto/Map/Fort/FortData.proto
+++ b/proto/Map/Fort/FortData.proto
@@ -10,7 +10,6 @@ import "POGOProtos/Map/Fort/GymDisplay.proto";
 import "POGOProtos/Map/Fort/FortType.proto";
 import "POGOProtos/Map/Fort/FortSponsor.proto";
 import "POGOProtos/Map/Fort/FortRenderingType.proto";
-import "POGOProtos/Map/Fort/FortLureInfo.proto";
 import "POGOProtos/Map/Pokemon/MapPokemon.proto";
 
 message FortData {


### PR DESCRIPTION
POGOProtos/Map/Fort/FortData.proto: warning: Import POGOProtos/Map/Fort/FortLureInfo.proto but not used.